### PR TITLE
Resolve nekojira/wp-php-console#2

### DIFF
--- a/lib/class-wp-php-console.php
+++ b/lib/class-wp-php-console.php
@@ -274,6 +274,11 @@ class WP_PHP_Console {
 		if ( ! $password )
 			return;
 
+		// Selectively remove slashes added by WordPress as expected by PhpConsole
+		if(isset($_POST[PhpConsole\Connector::POST_VAR_NAME])) {
+			$_POST[PhpConsole\Connector::POST_VAR_NAME] = stripslashes_deep($_POST[PhpConsole\Connector::POST_VAR_NAME]);
+		}
+
 		$connector = PhpConsole\Connector::getInstance();
 		$connector->setPassword( $password );
 


### PR DESCRIPTION
Without this patch, a `'`, `"` or `\` in the PHP console input for evaluation by the server is refused with `Wrong PHP Console eval request signature`
Resolves nekojira/wp-php-console#2
Clean alternative to #1 (although it modifies $_POST, which this issue has proven to be a bad idea ;-)
